### PR TITLE
Fix table rendering issue

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -40,6 +40,7 @@ flow:
 
             |Arm ML Inference Advisor|The Arm ML Inference Advisor (Arm MLIA) helps AI developers design and optimize neural network models for efficient inference on Arm targets. Arm MLIA enables insights into how the ML model will perform on Arm early in the model development cycle. With the tool, we aim to make the Arm ML IP accessible to developers at all levels of abstraction, with differing knowledge on hardware optimization and machine learning. For more details see: [https://pypi.org/project/mlia/](https://pypi.org/project/mlia/)|
 
+
             ## Our Focus
 
 


### PR DESCRIPTION
In the About section, a newline was missing to correctly render the markdown. This PR would add it in to fix the table.

The current broken table can be seen here: [https://www.mlplatform.org/about/](https://www.mlplatform.org/about/) 